### PR TITLE
fix: it should not break a computed signal to watch it before getting its value

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -275,12 +275,6 @@ export function producerIncrementEpoch(): void {
  * Ensure this producer's `version` is up-to-date.
  */
 export function producerUpdateValueVersion(node: ReactiveNode): void {
-  if (consumerIsLive(node) && !node.dirty) {
-    // A live consumer will be marked dirty by producers, so a clean state means that its version
-    // is guaranteed to be up-to-date.
-    return;
-  }
-
   if (!node.dirty && node.lastCleanEpoch === epoch) {
     // Even non-live consumers can skip polling if they previously found themselves to be clean at
     // the current epoch, since their dependencies could not possibly have changed (such a change

--- a/tests/Signal/subtle/watcher.test.ts
+++ b/tests/Signal/subtle/watcher.test.ts
@@ -178,4 +178,16 @@ describe('Watcher', () => {
     signal.set(1);
     expect(mockGetPending).toBeCalled();
   });
+
+  it('should not break a computed signal to watch it before getting its value', () => {
+    const signal = new Signal.State(0);
+    const computedSignal = new Signal.Computed(() => signal.get());
+    const watcher = new Signal.subtle.Watcher(() => {});
+    expect(computedSignal.get()).toBe(0);
+    signal.set(1);
+    watcher.watch(computedSignal);
+    expect(computedSignal.get()).toBe(1);
+    watcher.unwatch(computedSignal);
+    expect(computedSignal.get()).toBe(1);
+  });
 });


### PR DESCRIPTION
This PR fixes https://github.com/tc39/proposal-signals/issues/216