### PR TITLE
Use prepare script allowing usage from git npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite",
-    "prepack": "npm run build",
+    "prepare": "npm run build",
     "lint": "prettier --check .",
     "lint:fix": "prettier --write .",
     "test": "vitest"


### PR DESCRIPTION
This PR replaces the `prepack` script with the `prepare` script, so that it is easy for any depending package to try any branch of any fork of the `signal-polyfill` repository with the [git url](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#git-urls-as-dependencies) or the [github url](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#github-urls) syntax in the `package.json` file. For example:

```json
{
  "dependencies": {
    "signal-polyfill": "divdavem/signal-polyfill#prepareScript"
  }
}
```

As mentioned in [npm documentation](https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts):

> NOTE: If a package being installed through git contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.

Without this change, the build process is not run automatically by npm and the installed package is not directly usable when referred through a git or github url dependency in `package.json`.

Note that, even though, according to the npm documentation `prepack` is supposed to be called as well in this case (`Runs BEFORE a tarball is packed (on "npm pack", "npm publish", and when installing a git dependency).`), in practice, I did not find the `dist` folder when trying with the `prepack` script instead of `prepare`.
