### PR TITLE
Turn off minify for release bundle

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ const entry = join(dirname(fileURLToPath(import.meta.url)), './src/index.ts');
 export default defineConfig({
   plugins: [dts()],
   build: {
+    minify: false,
     lib: {
       entry,
       formats: ["es"],


### PR DESCRIPTION
I found it quite difficult to debug and patch the signal-polyfill package while working on [this PR](https://github.com/proposal-signals/signal-utils/pull/72) because this package is shipped to npm as a minified bundle. Since this is a not-for-production prototype and debugging/understanding it is one of the main purposes of it right now, maybe it makes sense to switch off minification?


Before:
<img width="501" alt="image" src="https://github.com/proposal-signals/signal-polyfill/assets/1242537/de300102-fa8b-405d-8f84-e1c4bcfc8bac">

After:
<img width="567" alt="image" src="https://github.com/proposal-signals/signal-polyfill/assets/1242537/cfc14596-ed7a-408e-be9f-fbca8a4b257c">
