### PR TITLE
[throwaway proposal] Add Effect node

### DIFF
--- a/src/effect.ts
+++ b/src/effect.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  REACTIVE_NODE,
+  ReactiveNode,
+  consumerAfterComputation,
+  consumerBeforeComputation,
+  consumerMarkClean,
+  isInNotificationPhase,
+  producerUpdateValueVersion,
+} from "./graph.js";
+
+/**
+ * A computation, which derives a value from a declarative reactive expression.
+ *
+ * `Effects`s are only consumers of reactivity.
+ */
+export interface EffectNode<T> extends ReactiveNode {
+  /**
+   * The computation function which will produce a new value.
+   */
+  executeEffect: () => T;
+}
+
+export function effectExecute<T>(node: EffectNode<T>): T {
+  if (isInNotificationPhase()) {
+    throw new Error(
+      "Effects cannot be executed during the notification phase."
+    );
+  }
+  const prevConsumer = consumerBeforeComputation(node);
+  try {
+    return node.executeEffect();
+  } finally {
+    consumerAfterComputation(node, prevConsumer);
+    // Even if the effect throws, mark it as clean.
+    consumerMarkClean(node);
+    if (!node?.producerNode?.length) {
+      throw new Error("Effects must consume at least one Signal.");
+    }
+  }
+}
+
+export function shouldEffectExecute<T>(node: EffectNode<T>): boolean {
+  if (!node.producerNode) return true;
+  for (let i = 0; i < node.producerNode.length; i++) {
+    producerUpdateValueVersion(node.producerNode[i]);
+    if (node.producerLastReadVersion?.[i] !== node.producerNode[i].version) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Create a computed signal which derives a reactive value from an expression.
+ */
+export function createEffectNode<T>(executeEffect: () => T): EffectNode<T> {
+  const node: EffectNode<T> = Object.create(EFFECT_NODE);
+  node.executeEffect = executeEffect;
+  return node;
+}
+
+// Note: Using an IIFE here to ensure that the spread assignment is not considered
+// a side-effect, ending up preserving `EFFECT_NODE` and `REACTIVE_NODE`.
+// TODO: remove when https://github.com/evanw/esbuild/issues/3392 is resolved.
+const EFFECT_NODE = /* @__PURE__ */ (() => {
+  return {
+    ...REACTIVE_NODE,
+    dirty: true,
+    executeEffect: () => {},
+  };
+})();

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -13,6 +13,7 @@ import {
   consumerBeforeComputation,
   consumerMarkClean,
   isInNotificationPhase,
+  producerAccessed,
   producerUpdateValueVersion,
 } from "./graph.js";
 
@@ -36,6 +37,8 @@ export function effectExecute<T>(node: EffectNode<T>): T {
   }
   const prevConsumer = consumerBeforeComputation(node);
   try {
+    node.version++;
+    producerAccessed(node);
     return node.executeEffect();
   } finally {
     consumerAfterComputation(node, prevConsumer);

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -290,14 +290,20 @@ export function producerUpdateValueVersion(node: ReactiveNode): void {
   if (!node.producerMustRecompute(node) && !consumerPollProducersForChange(node)) {
     // None of our producers report a change since the last time they were read, so no
     // recomputation of our value is necessary, and we can consider ourselves clean.
-    node.dirty = false;
-    node.lastCleanEpoch = epoch;
+    consumerMarkClean(node);
     return;
   }
 
   node.producerRecomputeValue(node);
 
   // After recomputing the value, we're no longer dirty.
+  consumerMarkClean(node);
+}
+
+/**
+ * Mark this consumer as clean.
+ */
+export function consumerMarkClean(node: ReactiveNode): void {
   node.dirty = false;
   node.lastCleanEpoch = epoch;
 }

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -280,10 +280,14 @@ export namespace subtle {
       const node = this[NODE];
       node.dirty = false;  // Give the watcher a chance to trigger again
       const prev = setActiveConsumer(node);
-      for (const signal of items) {
-        producerAccessed(signal[NODE]);
+      try {
+        // producerAccessed will throw if called during the notify phase
+        for (const signal of items) {
+          producerAccessed(signal[NODE]);
+        }
+      } finally {
+        setActiveConsumer(prev);
       }
-      setActiveConsumer(prev);
     }
 
     // Remove these signals from the watched set (e.g., for an effect which is disposed)

--- a/tests/Signal/effect.test.ts
+++ b/tests/Signal/effect.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { Signal } from "../../src/wrapper";
+
+describe("Effect", () => {
+  it("should throw an error if you do not deref any signals", () => {
+    expect(() => {
+      new Signal.subtle.Effect(() => {}).execute();
+    }).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Effects must consume at least one Signal.]`
+    );
+  });
+
+  it("should run the exec function whenever you call execute", () => {
+    let numExecutes = 0;
+    const signal = new Signal.State(1);
+    const effect = new Signal.subtle.Effect(() => {
+      signal.get();
+      numExecutes++;
+      return "hello " + numExecutes;
+    });
+
+    expect(effect.execute()).toBe("hello 1");
+    expect(effect.execute()).toBe("hello 2");
+    expect(effect.execute()).toBe("hello 3");
+  });
+
+  it("has a shouldExecute method that returns true if the effect has not been executed yet or if any of the signals have changed", () => {
+    let numExecutes = 0;
+    const signal = new Signal.State(1);
+    const effect = new Signal.subtle.Effect(() => {
+      signal.get();
+      numExecutes++;
+      return "hello " + numExecutes;
+    });
+
+    expect(effect.shouldExecute()).toBe(true);
+    expect(effect.execute()).toBe("hello 1");
+    expect(effect.shouldExecute()).toBe(false);
+    expect(effect.execute()).toBe("hello 2");
+    signal.set(2);
+    expect(effect.shouldExecute()).toBe(true);
+    expect(effect.execute()).toBe("hello 3");
+    expect(effect.shouldExecute()).toBe(false);
+  });
+
+  it("should have sources", () => {
+    const signal = new Signal.State(1);
+    const effect = new Signal.subtle.Effect(() => {
+      signal.get();
+    });
+
+    expect(Signal.subtle.introspectSources(effect)).toHaveLength(0);
+    effect.execute();
+    expect(Signal.subtle.introspectSources(effect)).toHaveLength(1);
+  });
+
+  it("should have sinks", () => {
+    const signal = new Signal.State(1);
+    const effect = new Signal.subtle.Effect(() => {
+      signal.get();
+    });
+    const watcher = new Signal.subtle.Watcher(() => {});
+    watcher.watch(effect);
+    effect.execute();
+
+    expect(Signal.subtle.introspectSinks(effect)).toHaveLength(1);
+  });
+
+  it("should allow reacting to changes in signals via Watcher", async () => {
+    const signal = new Signal.State(1);
+    let numExecutes = 0;
+    const effect = new Signal.subtle.Effect(() => {
+      numExecutes++;
+      return "hello " + signal.get();
+    });
+    expect(effect.execute()).toBe("hello 1");
+    const watcher = new Signal.subtle.Watcher(async () => {
+      watcher.watch();
+      await 0;
+      if (effect.shouldExecute()) {
+        effect.execute();
+      }
+    });
+
+    watcher.watch(effect);
+
+    expect(numExecutes).toBe(1);
+    signal.set(2);
+    await 0;
+    expect(numExecutes).toBe(2);
+    signal.set(3);
+    await 0;
+    expect(numExecutes).toBe(3);
+
+    expect(effect.execute()).toBe("hello 3");
+    expect(numExecutes).toBe(4);
+
+    expect(effect.execute()).toBe("hello 3");
+    expect(numExecutes).toBe(5);
+  });
+});


### PR DESCRIPTION
A couple of things came up while working on the React bindings in https://github.com/proposal-signals/signal-utils/pull/72, and I believe they've come up in other contexts:

1. We need a way to force tracked functions to execute even if the sources they track have not updated since the last invocation.
2. We need a way to detect whether the sources of a tracked function have _actually_ changed since the previous invocation. Simply knowing whether they _might_ have changed is not enough to allow the fine-grained reactivity of signals to be seamlessly syncrhonized with external systems like React.

Rather than bog down the `Computed` class with special behaviours to allow it to be used for side effects, I think it would be cleaner, both in terms of API design and implementation/maintainability, to add a new `subtle.Effect` type.

This PR adds the Effect type with a constructor signature of `new Effect<T>(run: () => T)` and with two public methods:

- `Effect#execute(): T` - runs the effect in a tracked context, returning the result. Does not cache the result.
- `Effect#shouldExecute(): boolean` - returns true if the effect has never run before, or if any of its sources have changed since the last time it ran.

And otherwise the effect instances behave similarly to computeds in that you pass them to a watcher to make them active, and they can be tracked by other effects.

### Why is this proposal marked as 'throwaway'?

I'm simultaneously working on another (larger) API refactor that does away with the `Watcher` class which I believe is quite unwieldy, replacing it with more user-friendly primitives without sacrificing expressiveness. Not quite ready to share that idea yet.