### PR TITLE
Fix unwatch multiple signals

### DIFF
--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -227,28 +227,25 @@ export namespace Signal {
         const node = this[NODE];
         assertConsumerNode(node);
 
-        let indicesToShift = [];
-        for (let i = 0; i < node.producerNode.length; i++) {
+        for (let i = node.producerNode.length - 1; i >= 0; i--) {
           if (signals.includes(node.producerNode[i].wrapper)) {
             producerRemoveLiveConsumerAtIndex(node.producerNode[i], node.producerIndexOfThis[i]);
-            indicesToShift.push(i);
-          }
-        }
-        for (const idx of indicesToShift) {
-          // Logic copied from producerRemoveLiveConsumerAtIndex, but reversed
-          const lastIdx = node.producerNode!.length - 1;
-          node.producerNode![idx] = node.producerNode![lastIdx];
-          node.producerIndexOfThis[idx] = node.producerIndexOfThis[lastIdx];
 
-          node.producerNode.length--;
-          node.producerIndexOfThis.length--;
-          node.nextProducerIndex--;
+            // Logic copied from producerRemoveLiveConsumerAtIndex, but reversed
+            const lastIdx = node.producerNode!.length - 1;
+            node.producerNode![i] = node.producerNode![lastIdx];
+            node.producerIndexOfThis[i] = node.producerIndexOfThis[lastIdx];
 
-          if (idx < node.producerNode.length) {
-            const idxConsumer = node.producerIndexOfThis[idx];
-            const producer = node.producerNode[idx];
-            assertProducerNode(producer);
-            producer.liveConsumerIndexOfThis[idxConsumer] = idx;
+            node.producerNode.length--;
+            node.producerIndexOfThis.length--;
+            node.nextProducerIndex--;
+
+            if (i < node.producerNode.length) {
+              const idxConsumer = node.producerIndexOfThis[i];
+              const producer = node.producerNode[i];
+              assertProducerNode(producer);
+              producer.liveConsumerIndexOfThis[idxConsumer] = i;
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes #2

The issue arises when removing an element, which shifts the last element to the current index. As a result, the last index goes out of bounds, and the moved element remains unprocessed.

To address this, iterate backward so that the removed element is replaced with a checked element, while the others remain unchanged.
