### PR TITLE
Add prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+*.md
+*.yaml
+*.yml
+node_modules/
+dist/


### PR DESCRIPTION
CI is failing because automation generated some changelog entries, and prettier doesn't agree with how the changelog is formatted.