### PR TITLE
Export isState, isComputed, isWatcher checks

### DIFF
--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -34,8 +34,9 @@ const NODE: unique symbol = Symbol('node');
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Signal {
-
-  export let isState: (s: any) => boolean, isComputed: (s: any) => boolean, isWatcher: (s: any) => boolean;
+  export let isState: (s: any) => boolean,
+    isComputed: (s: any) => boolean,
+    isWatcher: (s: any) => boolean;
 
   // A read-write Signal
   export class State<T> {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -32,10 +32,11 @@ import {createSignal, signalGetFn, signalSetFn, type SignalNode} from './signal.
 
 const NODE: unique symbol = Symbol('node');
 
-let isState: (s: any) => boolean, isComputed: (s: any) => boolean, isWatcher: (s: any) => boolean;
-
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Signal {
+
+  export let isState: (s: any) => boolean, isComputed: (s: any) => boolean, isWatcher: (s: any) => boolean;
+
   // A read-write Signal
   export class State<T> {
     readonly [NODE]: SignalNode<T>;


### PR DESCRIPTION
Previously, Signal.isState(), Signal.isComputed(), and Signal.isWatcher() were not actually usable checks (they were seen as undefined keys on the Signal namespace). This corrects how they are exposed for use. Necessary for the makeStore/makeState/makeMemo PR in the Signal-Utils repo.