### PR TITLE
Benchmarks from js-reactivity-benchmark in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,20 @@ concurrency:
   group: ci-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   test:
     name: 'Test ${{ matrix.testenv.name }}'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     strategy:
       matrix:
         testenv:
           - {name: 'Node', args: ''}
-          - {name: 'Chrome', args: '--browser.name=chrome --browser.headless'}
-          - {name: 'Firefox', args: '--browser.name=firefox --browser.headless'}
+          - {name: 'Chrome', args: '--browser.provider=webdriverio --browser.name=chrome --browser.headless'}
+          - {name: 'Firefox', args: '--browser.provider=webdriverio --browser.name=firefox --browser.headless'}
 
     steps:
       - uses: actions/checkout@v4
@@ -29,3 +32,15 @@ jobs:
       - run: pnpm lint
       - run: pnpm build
       - run: pnpm vitest ${{ matrix.testenv.args }}
+      - run: pnpm vitest bench
+        if: matrix.testenv.name == 'Node'
+      - uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 #v1.20.4
+        if: matrix.testenv.name == 'Node'
+        with:
+          name: Benchmarks
+          tool: 'customBiggerIsBetter'
+          output-file-path: benchmarks.json
+          auto-push: ${{ github.event_name == 'push' }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-on-alert: true
+          summary-always: true

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ build
 dist/
 *.tsbuildinfo
 .DS_Store
+
+# Benchmarks result:
+benchmarks.json

--- a/benchmarks/effect.ts
+++ b/benchmarks/effect.ts
@@ -1,0 +1,33 @@
+import {Signal} from '../src';
+
+const queue: Signal.Computed<any>[] = [];
+
+export const effect = (fn: () => void) => {
+  const c = new Signal.Computed(fn);
+  const watcher = new Signal.subtle.Watcher(() => {
+    if (inBatch === 0) {
+      throw new Error('signal changed outside of batch');
+    }
+    queue.push(c);
+    watcher.watch(); // re-enable watcher
+  });
+  c.get();
+  watcher.watch(c);
+};
+
+const processQueue = () => {
+  while (queue.length) {
+    queue.shift()!.get();
+  }
+};
+
+let inBatch = 0;
+export const batch = (fn: () => void) => {
+  inBatch++;
+  try {
+    fn();
+  } finally {
+    inBatch--;
+    if (inBatch === 0) processQueue();
+  }
+};

--- a/benchmarks/gc.ts
+++ b/benchmarks/gc.ts
@@ -1,0 +1,6 @@
+const gc = globalThis.gc;
+export const setup = gc
+  ? () => {
+      gc();
+    }
+  : () => {};

--- a/benchmarks/js-reactivity-benchmarks/cellxBench.bench.ts
+++ b/benchmarks/js-reactivity-benchmarks/cellxBench.bench.ts
@@ -1,0 +1,94 @@
+// adapted from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/cellxBench.ts
+
+import {bench, expect} from 'vitest';
+import {Signal} from '../../src';
+import {setup} from '../gc';
+import {effect, batch} from '../effect';
+
+// The following is an implementation of the cellx benchmark https://github.com/Riim/cellx/blob/master/perf/perf.html
+
+const cellx = (
+  layers: number,
+  expectedBefore: readonly [number, number, number, number],
+  expectedAfter: readonly [number, number, number, number],
+) => {
+  const start = {
+    prop1: new Signal.State(1),
+    prop2: new Signal.State(2),
+    prop3: new Signal.State(3),
+    prop4: new Signal.State(4),
+  };
+
+  let layer: {
+    prop1: Signal.Computed<number> | Signal.State<number>;
+    prop2: Signal.Computed<number> | Signal.State<number>;
+    prop3: Signal.Computed<number> | Signal.State<number>;
+    prop4: Signal.Computed<number> | Signal.State<number>;
+  } = start;
+
+  for (let i = layers; i > 0; i--) {
+    const m = layer;
+    const s = {
+      prop1: new Signal.Computed(() => m.prop2.get()),
+      prop2: new Signal.Computed(() => m.prop1.get() - m.prop3.get()),
+      prop3: new Signal.Computed(() => m.prop2.get() + m.prop4.get()),
+      prop4: new Signal.Computed(() => m.prop3.get()),
+    };
+
+    effect(() => s.prop1.get());
+    effect(() => s.prop2.get());
+    effect(() => s.prop3.get());
+    effect(() => s.prop4.get());
+
+    s.prop1.get();
+    s.prop2.get();
+    s.prop3.get();
+    s.prop4.get();
+
+    layer = s;
+  }
+
+  const end = layer;
+
+  expect(end.prop1.get()).toBe(expectedBefore[0]);
+  expect(end.prop2.get()).toBe(expectedBefore[1]);
+  expect(end.prop3.get()).toBe(expectedBefore[2]);
+  expect(end.prop4.get()).toBe(expectedBefore[3]);
+
+  batch(() => {
+    start.prop1.set(4);
+    start.prop2.set(3);
+    start.prop3.set(2);
+    start.prop4.set(1);
+  });
+
+  expect(end.prop1.get()).toBe(expectedAfter[0]);
+  expect(end.prop2.get()).toBe(expectedAfter[1]);
+  expect(end.prop3.get()).toBe(expectedAfter[2]);
+  expect(end.prop4.get()).toBe(expectedAfter[3]);
+};
+
+type BenchmarkResults = [
+  readonly [number, number, number, number],
+  readonly [number, number, number, number],
+];
+
+const expected: Record<number, BenchmarkResults> = {
+  1000: [
+    [-3, -6, -2, 2],
+    [-2, -4, 2, 3],
+  ],
+  2500: [
+    [-3, -6, -2, 2],
+    [-2, -4, 2, 3],
+  ],
+  5000: [
+    [2, 4, -1, -6],
+    [-2, 1, -4, -4],
+  ],
+};
+
+for (const layers in expected) {
+  const params = expected[layers];
+  bench(`cellx${layers}`, () => cellx(+layers, params[0], params[1]), {throws: true, setup});
+}

--- a/benchmarks/js-reactivity-benchmarks/dynamic.bench.ts
+++ b/benchmarks/js-reactivity-benchmarks/dynamic.bench.ts
@@ -1,0 +1,329 @@
+// adapted from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/dynamicBench.ts
+
+import {bench, expect} from 'vitest';
+import {Signal} from '../../src';
+import {setup} from '../gc';
+import {batch} from '../effect';
+
+// from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/util/pseudoRandom.ts
+
+export function pseudoRandom(seed = 'seed'): () => number {
+  const hash = xmur3a(seed);
+  const rng = sfc32(hash(), hash(), hash(), hash());
+  return rng;
+}
+
+/* these are adapted from https://github.com/bryc/code/blob/master/jshash/PRNGs.md
+ * (License: Public domain) */
+
+/** random number generator originally in PractRand */
+function sfc32(a: number, b: number, c: number, d: number): () => number {
+  return function () {
+    a >>>= 0;
+    b >>>= 0;
+    c >>>= 0;
+    d >>>= 0;
+    let t = (a + b) | 0;
+    a = b ^ (b >>> 9);
+    b = (c + (c << 3)) | 0;
+    c = (c << 21) | (c >>> 11);
+    d = (d + 1) | 0;
+    t = (t + d) | 0;
+    c = (c + t) | 0;
+    return (t >>> 0) / 4294967296;
+  };
+}
+
+/** MurmurHash3 */
+export function xmur3a(str: string): () => number {
+  let h = 2166136261 >>> 0;
+  for (let k: number, i = 0; i < str.length; i++) {
+    k = Math.imul(str.charCodeAt(i), 3432918353);
+    k = (k << 15) | (k >>> 17);
+    h ^= Math.imul(k, 461845907);
+    h = (h << 13) | (h >>> 19);
+    h = (Math.imul(h, 5) + 3864292196) | 0;
+  }
+  h ^= str.length;
+  return function () {
+    h ^= h >>> 16;
+    h = Math.imul(h, 2246822507);
+    h ^= h >>> 13;
+    h = Math.imul(h, 3266489909);
+    h ^= h >>> 16;
+    return h >>> 0;
+  };
+}
+
+// from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/util/perfTests.ts
+
+export interface TestResult {
+  sum: number;
+  count: number;
+}
+
+// from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/util/frameworkTypes.ts
+
+interface TestConfig {
+  /** friendly name for the test, should be unique */
+  name?: string;
+
+  /** width of dependency graph to construct */
+  width: number;
+
+  /** depth of dependency graph to construct */
+  totalLayers: number;
+
+  /** fraction of nodes that are static */ // TODO change to dynamicFraction
+  staticFraction: number;
+
+  /** construct a graph with number of sources in each node */
+  nSources: number;
+
+  /** fraction of [0, 1] elements in the last layer from which to read values in each test iteration */
+  readFraction: number;
+
+  /** number of test iterations */
+  iterations: number;
+
+  /** sum and count of all iterations, for verification */
+  expected: Partial<TestResult>;
+}
+
+// from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/util/dependencyGraph.ts
+
+interface Graph {
+  sources: Signal.State<number>[];
+  layers: Signal.Computed<number>[][];
+}
+
+interface GraphAndCounter {
+  graph: Graph;
+  counter: Counter;
+}
+
+/**
+ * Make a rectangular dependency graph, with an equal number of source elements
+ * and computation elements at every layer.
+ *
+ * @param width number of source elements and number of computed elements per layer
+ * @param totalLayers total number of source and computed layers
+ * @param staticFraction every nth computed node is static (1 = all static, 3 = 2/3rd are dynamic)
+ * @returns the graph
+ */
+function makeGraph(config: TestConfig): GraphAndCounter {
+  const {width, totalLayers, staticFraction, nSources} = config;
+
+  const sources = new Array(width).fill(0).map((_, i) => new Signal.State(i));
+  const counter = new Counter();
+  const rows = makeDependentRows(sources, totalLayers - 1, counter, staticFraction, nSources);
+  const graph = {sources, layers: rows};
+  return {graph, counter};
+}
+
+/**
+ * Execute the graph by writing one of the sources and reading some or all of the leaves.
+ *
+ * @return the sum of all leaf values
+ */
+function runGraph(graph: Graph, iterations: number, readFraction: number): number {
+  const rand = pseudoRandom();
+  const {sources, layers} = graph;
+  const leaves = layers[layers.length - 1];
+  const skipCount = Math.round(leaves.length * (1 - readFraction));
+  const readLeaves = removeElems(leaves, skipCount, rand);
+
+  for (let i = 0; i < iterations; i++) {
+    const sourceDex = i % sources.length;
+    batch(() => {
+      sources[sourceDex].set(i + sourceDex);
+    });
+    for (const leaf of readLeaves) {
+      leaf.get();
+    }
+  }
+
+  const sum = readLeaves.reduce((total, leaf) => leaf.get() + total, 0);
+  return sum;
+}
+
+function removeElems<T>(src: T[], rmCount: number, rand: () => number): T[] {
+  const copy = src.slice();
+  for (let i = 0; i < rmCount; i++) {
+    const rmDex = Math.floor(rand() * copy.length);
+    copy.splice(rmDex, 1);
+  }
+  return copy;
+}
+
+class Counter {
+  count = 0;
+}
+
+function makeDependentRows(
+  sources: (Signal.Computed<number> | Signal.State<number>)[],
+  numRows: number,
+  counter: Counter,
+  staticFraction: number,
+  nSources: number,
+): Signal.Computed<number>[][] {
+  let prevRow = sources;
+  const random = pseudoRandom();
+  const rows: Signal.Computed<number>[][] = [];
+  for (let l = 0; l < numRows; l++) {
+    const row = makeRow(prevRow, counter, staticFraction, nSources, l, random);
+    rows.push(row);
+    prevRow = row;
+  }
+  return rows;
+}
+
+function makeRow(
+  sources: (Signal.Computed<number> | Signal.State<number>)[],
+  counter: Counter,
+  staticFraction: number,
+  nSources: number,
+  layer: number,
+  random: () => number,
+): Signal.Computed<number>[] {
+  return sources.map((_, myDex) => {
+    const mySources: (Signal.Computed<number> | Signal.State<number>)[] = [];
+    for (let sourceDex = 0; sourceDex < nSources; sourceDex++) {
+      mySources.push(sources[(myDex + sourceDex) % sources.length]);
+    }
+
+    const staticNode = random() < staticFraction;
+    if (staticNode) {
+      // static node, always reference sources
+      return new Signal.Computed(() => {
+        counter.count++;
+
+        let sum = 0;
+        for (const src of mySources) {
+          sum += src.get();
+        }
+        return sum;
+      });
+    } else {
+      // dynamic node, drops one of the sources depending on the value of the first element
+      const first = mySources[0];
+      const tail = mySources.slice(1);
+      const node = new Signal.Computed(() => {
+        counter.count++;
+        let sum = first.get();
+        const shouldDrop = sum & 0x1;
+        const dropDex = sum % tail.length;
+
+        for (let i = 0; i < tail.length; i++) {
+          if (shouldDrop && i === dropDex) continue;
+          sum += tail[i].get();
+        }
+
+        return sum;
+      });
+      return node;
+    }
+  });
+}
+
+// cf https://github.com/milomg/js-reactivity-benchmark/blob/main/src/config.ts
+const perfTests = [
+  {
+    name: 'simple component',
+    width: 10, // can't change for decorator tests
+    staticFraction: 1, // can't change for decorator tests
+    nSources: 2, // can't change for decorator tests
+    totalLayers: 5,
+    readFraction: 0.2,
+    iterations: 600000,
+    expected: {
+      sum: 19199968,
+      count: 3480000,
+    },
+  },
+  {
+    name: 'dynamic component',
+    width: 10,
+    totalLayers: 10,
+    staticFraction: 3 / 4,
+    nSources: 6,
+    readFraction: 0.2,
+    iterations: 15000,
+    expected: {
+      sum: 302310782860,
+      count: 1155000,
+    },
+  },
+  {
+    name: 'large web app',
+    width: 1000,
+    totalLayers: 12,
+    staticFraction: 0.95,
+    nSources: 4,
+    readFraction: 1,
+    iterations: 7000,
+    expected: {
+      sum: 29355933696000,
+      count: 1463000,
+    },
+  },
+  {
+    name: 'wide dense',
+    width: 1000,
+    totalLayers: 5,
+    staticFraction: 1,
+    nSources: 25,
+    readFraction: 1,
+    iterations: 3000,
+    expected: {
+      sum: 1171484375000,
+      count: 732000,
+    },
+  },
+  {
+    name: 'deep',
+    width: 5,
+    totalLayers: 500,
+    staticFraction: 1,
+    nSources: 3,
+    readFraction: 1,
+    iterations: 500,
+    expected: {
+      sum: 3.0239642676898464e241,
+      count: 1246500,
+    },
+  },
+  {
+    name: 'very dynamic',
+    width: 100,
+    totalLayers: 15,
+    staticFraction: 0.5,
+    nSources: 6,
+    readFraction: 1,
+    iterations: 2000,
+    expected: {
+      sum: 15664996402790400,
+      count: 1078000,
+    },
+  },
+];
+
+for (const config of perfTests) {
+  const {graph, counter} = makeGraph(config);
+
+  bench(
+    `dynamic ${config.name}`,
+    () => {
+      counter.count = 0;
+      const sum = runGraph(graph, config.iterations, config.readFraction);
+
+      if (config.expected.sum) {
+        expect(sum).toBe(config.expected.sum);
+      }
+      if (config.expected.count) {
+        expect(counter.count).toBe(config.expected.count);
+      }
+    },
+    {throws: true, setup},
+  );
+}

--- a/benchmarks/js-reactivity-benchmarks/kairo/avoidable.bench.ts
+++ b/benchmarks/js-reactivity-benchmarks/kairo/avoidable.bench.ts
@@ -1,0 +1,42 @@
+// adapted from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/kairo/avoidable.ts
+
+import {bench, expect} from 'vitest';
+import {Signal} from '../../../src';
+import {setup} from '../../gc';
+import {batch, effect} from '../../effect';
+
+function busy() {
+  let a = 0;
+  for (let i = 0; i < 1_00; i++) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    a++;
+  }
+}
+
+const head = new Signal.State(0);
+const computed1 = new Signal.Computed(() => head.get());
+const computed2 = new Signal.Computed(() => (computed1.get(), 0));
+const computed3 = new Signal.Computed(() => (busy(), computed2.get() + 1)); // heavy computation
+const computed4 = new Signal.Computed(() => computed3.get() + 2);
+const computed5 = new Signal.Computed(() => computed4.get() + 3);
+effect(() => {
+  computed5.get();
+  busy(); // heavy side effect
+});
+
+bench(
+  'avoidablePropagation',
+  () => {
+    batch(() => {
+      head.set(1);
+    });
+    expect(computed5.get()).toBe(6);
+    for (let i = 0; i < 1000; i++) {
+      batch(() => {
+        head.set(i);
+      });
+      expect(computed5.get()).toBe(6);
+    }
+  },
+  {throws: true, setup},
+);

--- a/benchmarks/js-reactivity-benchmarks/kairo/broad.bench.ts
+++ b/benchmarks/js-reactivity-benchmarks/kairo/broad.bench.ts
@@ -1,0 +1,44 @@
+// adapted from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/kairo/broad.ts
+
+import {bench, expect} from 'vitest';
+import {Signal} from '../../../src';
+import {setup} from '../../gc';
+import {batch, effect} from '../../effect';
+
+const loopCount = 50;
+
+const head = new Signal.State(0);
+let last: Signal.Computed<number> | Signal.State<number> = head;
+let callCounter = 0;
+for (let i = 0; i < loopCount; i++) {
+  const current = new Signal.Computed(() => {
+    return head.get() + i;
+  });
+  const current2 = new Signal.Computed(() => {
+    return current.get() + 1;
+  });
+  effect(() => {
+    current2.get();
+    callCounter++;
+  });
+  last = current2;
+}
+
+bench(
+  'broad',
+  () => {
+    batch(() => {
+      head.set(1);
+    });
+    const atleast = loopCount * loopCount;
+    callCounter = 0;
+    for (let i = 0; i < loopCount; i++) {
+      batch(() => {
+        head.set(i);
+      });
+      expect(last.get()).toBe(i + loopCount);
+    }
+    expect(callCounter).toBe(atleast);
+  },
+  {throws: true, setup},
+);

--- a/benchmarks/js-reactivity-benchmarks/kairo/deep.bench.ts
+++ b/benchmarks/js-reactivity-benchmarks/kairo/deep.bench.ts
@@ -1,0 +1,44 @@
+// adapted from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/kairo/deep.ts
+
+import {bench, expect} from 'vitest';
+import {Signal} from '../../../src';
+import {setup} from '../../gc';
+import {batch, effect} from '../../effect';
+
+const len = 50;
+
+const head = new Signal.State(0);
+let current: Signal.State<number> | Signal.Computed<number> = head;
+for (let i = 0; i < len; i++) {
+  const c = current;
+  current = new Signal.Computed(() => {
+    return c.get() + 1;
+  });
+}
+let callCounter = 0;
+
+effect(() => {
+  current.get();
+  callCounter++;
+});
+
+const iter = 50;
+
+bench(
+  'deep',
+  () => {
+    batch(() => {
+      head.set(1);
+    });
+    const atleast = iter;
+    callCounter = 0;
+    for (let i = 0; i < iter; i++) {
+      batch(() => {
+        head.set(i);
+      });
+      expect(current.get()).toBe(len + i);
+    }
+    expect(callCounter).toBe(atleast);
+  },
+  {throws: true, setup},
+);

--- a/benchmarks/js-reactivity-benchmarks/kairo/diamond.bench.ts
+++ b/benchmarks/js-reactivity-benchmarks/kairo/diamond.bench.ts
@@ -1,0 +1,40 @@
+// adapted from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/kairo/diamond.ts
+
+import {bench, expect} from 'vitest';
+import {Signal} from '../../../src';
+import {setup} from '../../gc';
+import {batch, effect} from '../../effect';
+
+const width = 5;
+
+const head = new Signal.State(0);
+const current: Signal.Computed<number>[] = [];
+for (let i = 0; i < width; i++) {
+  current.push(new Signal.Computed(() => head.get() + 1));
+}
+const sum = new Signal.Computed(() => current.map((x) => x.get()).reduce((a, b) => a + b, 0));
+let callCounter = 0;
+effect(() => {
+  sum.get();
+  callCounter++;
+});
+
+bench(
+  'diamond',
+  () => {
+    batch(() => {
+      head.set(1);
+    });
+    expect(sum.get()).toBe(2 * width);
+    const atleast = 500;
+    callCounter = 0;
+    for (let i = 0; i < 500; i++) {
+      batch(() => {
+        head.set(i);
+      });
+      expect(sum.get()).toBe((i + 1) * width);
+    }
+    expect(callCounter).toBe(atleast);
+  },
+  {throws: true, setup},
+);

--- a/benchmarks/js-reactivity-benchmarks/kairo/mux.bench.ts
+++ b/benchmarks/js-reactivity-benchmarks/kairo/mux.bench.ts
@@ -1,0 +1,37 @@
+// adapted from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/kairo/mux.ts
+
+import {bench, expect} from 'vitest';
+import {Signal} from '../../../src';
+import {setup} from '../../gc';
+import {batch, effect} from '../../effect';
+
+const heads = new Array(100).fill(null).map(() => new Signal.State(0));
+const mux = new Signal.Computed(() => {
+  return Object.fromEntries(heads.map((h) => h.get()).entries());
+});
+const splited = heads
+  .map((_, index) => new Signal.Computed(() => mux.get()[index]))
+  .map((x) => new Signal.Computed(() => x.get() + 1));
+
+splited.forEach((x) => {
+  effect(() => x.get());
+});
+
+bench(
+  'mux',
+  () => {
+    for (let i = 0; i < 10; i++) {
+      batch(() => {
+        heads[i].set(i);
+      });
+      expect(splited[i].get()).toBe(i + 1);
+    }
+    for (let i = 0; i < 10; i++) {
+      batch(() => {
+        heads[i].set(i * 2);
+      });
+      expect(splited[i].get()).toBe(i * 2 + 1);
+    }
+  },
+  {throws: true, setup},
+);

--- a/benchmarks/js-reactivity-benchmarks/kairo/repeated.bench.ts
+++ b/benchmarks/js-reactivity-benchmarks/kairo/repeated.bench.ts
@@ -1,0 +1,44 @@
+// adapted from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/kairo/repeated.ts
+
+import {bench, expect} from 'vitest';
+import {Signal} from '../../../src';
+import {setup} from '../../gc';
+import {batch, effect} from '../../effect';
+
+const size = 30;
+
+const head = new Signal.State(0);
+const current = new Signal.Computed(() => {
+  let result = 0;
+  for (let i = 0; i < size; i++) {
+    // tbh I think it's meanigless to be this big...
+    result += head.get();
+  }
+  return result;
+});
+
+let callCounter = 0;
+effect(() => {
+  current.get();
+  callCounter++;
+});
+
+bench(
+  'repeated',
+  () => {
+    batch(() => {
+      head.set(1);
+    });
+    expect(current.get()).toBe(size);
+    const atleast = 100;
+    callCounter = 0;
+    for (let i = 0; i < 100; i++) {
+      batch(() => {
+        head.set(i);
+      });
+      expect(current.get()).toBe(i * size);
+    }
+    expect(callCounter).toBe(atleast);
+  },
+  {throws: true, setup},
+);

--- a/benchmarks/js-reactivity-benchmarks/kairo/triangle.bench.ts
+++ b/benchmarks/js-reactivity-benchmarks/kairo/triangle.bench.ts
@@ -1,0 +1,57 @@
+// adapted from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/kairo/triangle.ts
+
+import {bench, expect} from 'vitest';
+import {Signal} from '../../../src';
+import {setup} from '../../gc';
+import {batch, effect} from '../../effect';
+
+const width = 10;
+
+const head = new Signal.State(0);
+let current: Signal.State<number> | Signal.Computed<number> = head;
+const list: (Signal.State<number> | Signal.Computed<number>)[] = [];
+for (let i = 0; i < width; i++) {
+  const c = current;
+  list.push(current);
+  current = new Signal.Computed(() => {
+    return c.get() + 1;
+  });
+}
+const sum = new Signal.Computed(() => {
+  return list.map((x) => x.get()).reduce((a, b) => a + b, 0);
+});
+
+let callCounter = 0;
+
+effect(() => {
+  sum.get();
+  callCounter++;
+});
+
+bench(
+  'triangle',
+  () => {
+    const constant = count(width);
+    batch(() => {
+      head.set(1);
+    });
+    expect(sum.get()).toBe(constant);
+    const atleast = 100;
+    callCounter = 0;
+    for (let i = 0; i < 100; i++) {
+      batch(() => {
+        head.set(i);
+      });
+      expect(sum.get()).toBe(constant - width + i * width);
+    }
+    expect(callCounter).toBe(atleast);
+  },
+  {throws: true, setup},
+);
+
+function count(number: number) {
+  return new Array(number)
+    .fill(0)
+    .map((_, i) => i + 1)
+    .reduce((x, y) => x + y, 0);
+}

--- a/benchmarks/js-reactivity-benchmarks/kairo/unstable.bench.ts
+++ b/benchmarks/js-reactivity-benchmarks/kairo/unstable.bench.ts
@@ -1,0 +1,43 @@
+// adapted from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/kairo/unstable.ts
+
+import {bench, expect} from 'vitest';
+import {Signal} from '../../../src';
+import {setup} from '../../gc';
+import {batch, effect} from '../../effect';
+
+const head = new Signal.State(0);
+const double = new Signal.Computed(() => head.get() * 2);
+const inverse = new Signal.Computed(() => -head.get());
+const current = new Signal.Computed(() => {
+  let result = 0;
+  for (let i = 0; i < 20; i++) {
+    result += head.get() % 2 ? double.get() : inverse.get();
+  }
+  return result;
+});
+
+let callCounter = 0;
+effect(() => {
+  current.get();
+  callCounter++;
+});
+
+bench(
+  'unstable',
+  () => {
+    batch(() => {
+      head.set(1);
+    });
+    expect(current.get()).toBe(40);
+    const atleast = 100;
+    callCounter = 0;
+    for (let i = 0; i < 100; i++) {
+      batch(() => {
+        head.set(i);
+      });
+      // expect(current()).toBe(i % 2 ? i * 2 * 10 : i * -10);
+    }
+    expect(callCounter).toBe(atleast);
+  },
+  {throws: true, setup},
+);

--- a/benchmarks/js-reactivity-benchmarks/molBench.bench.ts
+++ b/benchmarks/js-reactivity-benchmarks/molBench.bench.ts
@@ -1,0 +1,48 @@
+// adapted from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/molBench.ts
+
+import {bench} from 'vitest';
+import {Signal} from '../../src';
+import {setup} from '../gc';
+import {batch, effect} from '../effect';
+
+function fib(n: number): number {
+  if (n < 2) return 1;
+  return fib(n - 1) + fib(n - 2);
+}
+
+function hard(n: number) {
+  return n + fib(16);
+}
+
+const numbers = Array.from({length: 5}, (_, i) => i);
+
+const res: number[] = [];
+
+const A = new Signal.State(0);
+const B = new Signal.State(0);
+const C = new Signal.Computed(() => (A.get() % 2) + (B.get() % 2));
+const D = new Signal.Computed(() => numbers.map((i) => ({x: i + (A.get() % 2) - (B.get() % 2)})));
+const E = new Signal.Computed(() => hard(C.get() + A.get() + D.get()[0].x /*, 'E'*/));
+const F = new Signal.Computed(() => hard(D.get()[2].x || B.get() /*, 'F'*/));
+const G = new Signal.Computed(() => C.get() + (C.get() || E.get() % 2) + D.get()[4].x + F.get());
+effect(() => res.push(hard(G.get() /*, 'H'*/)));
+effect(() => res.push(G.get()));
+effect(() => res.push(hard(F.get() /*, 'J'*/)));
+
+bench(
+  'molBench',
+  () => {
+    for (let i = 0; i < 1e4; i++) {
+      res.length = 0;
+      batch(() => {
+        B.set(1);
+        A.set(1 + i * 2);
+      });
+      batch(() => {
+        A.set(2 + i * 2);
+        B.set(2);
+      });
+    }
+  },
+  {throws: true, setup},
+);

--- a/benchmarks/js-reactivity-benchmarks/sBench.bench.ts
+++ b/benchmarks/js-reactivity-benchmarks/sBench.bench.ts
@@ -1,0 +1,260 @@
+// adapted from https://github.com/milomg/js-reactivity-benchmark/blob/main/src/sBench.ts
+
+import {bench} from 'vitest';
+import {Signal} from '../../src';
+import {setup} from '../gc';
+import {batch, effect} from '../effect';
+
+// Inspired by https://github.com/solidjs/solid/blob/main/packages/solid/bench/bench.cjs
+
+const COUNT = 1e4;
+
+type Reader = Signal.Computed<number> | Signal.State<number>;
+
+defineBench(onlyCreateDataSignals, COUNT, COUNT);
+defineBench(createComputations0to1, COUNT, 0);
+defineBench(createComputations1to1, COUNT, COUNT);
+defineBench(createComputations2to1, COUNT / 2, COUNT);
+defineBench(createComputations4to1, COUNT / 4, COUNT);
+defineBench(createComputations1000to1, COUNT / 1000, COUNT);
+// createTotal += bench(createComputations8to1, COUNT, 8 * COUNT);
+defineBench(createComputations1to2, COUNT, COUNT / 2);
+defineBench(createComputations1to4, COUNT, COUNT / 4);
+defineBench(createComputations1to8, COUNT, COUNT / 8);
+defineBench(createComputations1to1000, COUNT, COUNT / 1000);
+defineBench(updateComputations1to1, COUNT * 4, 1);
+defineBench(updateComputations2to1, COUNT * 2, 2);
+defineBench(updateComputations4to1, COUNT, 4);
+defineBench(updateComputations1000to1, COUNT / 100, 1000);
+defineBench(updateComputations1to2, COUNT * 4, 1);
+defineBench(updateComputations1to4, COUNT * 4, 1);
+defineBench(updateComputations1to1000, COUNT * 4, 1);
+
+function defineBench(fn: (n: number, sources: any[]) => void, n: number, scount: number) {
+  bench(fn.name, () => fn(n, createDataSignals(scount, [])), {throws: true, setup});
+}
+
+function onlyCreateDataSignals() {
+  // createDataSignals is already called before
+}
+
+function createDataSignals(n: number, sources: Signal.State<number>[]) {
+  for (let i = 0; i < n; i++) {
+    sources[i] = new Signal.State(i);
+  }
+  return sources;
+}
+
+function createComputations0to1(n: number /*, _sources: Signal.State<number>[]*/) {
+  for (let i = 0; i < n; i++) {
+    createComputation0(i);
+  }
+}
+
+function createComputations1to1000(n: number, sources: Signal.State<number>[]) {
+  for (let i = 0; i < n / 1000; i++) {
+    const get = sources[i];
+    for (let j = 0; j < 1000; j++) {
+      createComputation1(get);
+    }
+  }
+}
+
+function createComputations1to8(n: number, sources: Signal.State<number>[]) {
+  for (let i = 0; i < n / 8; i++) {
+    const get = sources[i];
+    createComputation1(get);
+    createComputation1(get);
+    createComputation1(get);
+    createComputation1(get);
+    createComputation1(get);
+    createComputation1(get);
+    createComputation1(get);
+    createComputation1(get);
+  }
+}
+
+function createComputations1to4(n: number, sources: Signal.State<number>[]) {
+  for (let i = 0; i < n / 4; i++) {
+    const get = sources[i];
+    createComputation1(get);
+    createComputation1(get);
+    createComputation1(get);
+    createComputation1(get);
+  }
+}
+
+function createComputations1to2(n: number, sources: Signal.State<number>[]) {
+  for (let i = 0; i < n / 2; i++) {
+    const get = sources[i];
+    createComputation1(get);
+    createComputation1(get);
+  }
+}
+
+function createComputations1to1(n: number, sources: Signal.State<number>[]) {
+  for (let i = 0; i < n; i++) {
+    const get = sources[i];
+    createComputation1(get);
+  }
+}
+
+function createComputations2to1(n: number, sources: Signal.State<number>[]) {
+  for (let i = 0; i < n; i++) {
+    createComputation2(sources[i * 2], sources[i * 2 + 1]);
+  }
+}
+
+function createComputations4to1(n: number, sources: Signal.State<number>[]) {
+  for (let i = 0; i < n; i++) {
+    createComputation4(sources[i * 4], sources[i * 4 + 1], sources[i * 4 + 2], sources[i * 4 + 3]);
+  }
+}
+
+// function createComputations8to1(n: number, sources: Signal.State<number>[]) {
+//   for (let i = 0; i < n; i++) {
+//     createComputation8(
+//       sources[i * 8],
+//       sources[i * 8 + 1],
+//       sources[i * 8 + 2],
+//       sources[i * 8 + 3],
+//       sources[i * 8 + 4],
+//       sources[i * 8 + 5],
+//       sources[i * 8 + 6],
+//       sources[i * 8 + 7]
+//     );
+//   }
+// }
+
+// only create n / 100 computations, as otherwise takes too long
+function createComputations1000to1(n: number, sources: Signal.State<number>[]) {
+  for (let i = 0; i < n; i++) {
+    createComputation1000(sources, i * 1000);
+  }
+}
+
+function createComputation0(i: number) {
+  effect(() => i);
+}
+
+function createComputation1(s1: Reader) {
+  effect(() => s1.get());
+}
+function createComputation2(s1: Reader, s2: Reader) {
+  effect(() => s1.get() + s2.get());
+}
+
+function createComputation4(s1: Reader, s2: Reader, s3: Reader, s4: Reader) {
+  effect(() => s1.get() + s2.get() + s3.get() + s4.get());
+}
+
+// function createComputation8(
+//   s1: Reader,
+//   s2: Reader,
+//   s3: Reader,
+//   s4: Reader,
+//   s5: Reader,
+//   s6: Reader,
+//   s7: Reader,
+//   s8: Reader
+// ) {
+//   computed(
+//     () => s1() + s2() + s3() + s4() + s5() + s6() + s7() + s8()
+//   );
+// }
+
+function createComputation1000(ss: Signal.State<number>[], offset: number) {
+  effect(() => {
+    let sum = 0;
+    for (let i = 0; i < 1000; i++) {
+      sum += ss[offset + i].get();
+    }
+    return sum;
+  });
+}
+
+function updateComputations1to1(n: number, sources: Signal.State<number>[]) {
+  const s1 = sources[0];
+  effect(() => s1.get());
+  for (let i = 0; i < n; i++) {
+    batch(() => {
+      s1.set(i);
+    });
+  }
+}
+
+function updateComputations2to1(n: number, sources: Signal.State<number>[]) {
+  const s1 = sources[0],
+    s2 = sources[1];
+  effect(() => s1.get() + s2.get());
+  for (let i = 0; i < n; i++) {
+    batch(() => {
+      s1.set(i);
+    });
+  }
+}
+
+function updateComputations4to1(n: number, sources: Signal.State<number>[]) {
+  const s1 = sources[0],
+    s2 = sources[1],
+    s3 = sources[2],
+    s4 = sources[3];
+  effect(() => s1.get() + s2.get() + s3.get() + s4.get());
+  for (let i = 0; i < n; i++) {
+    batch(() => {
+      s1.set(i);
+    });
+  }
+}
+
+function updateComputations1000to1(n: number, sources: Signal.State<number>[]) {
+  const s1 = sources[0];
+  effect(() => {
+    let sum = 0;
+    for (let i = 0; i < 1000; i++) {
+      sum += sources[i].get();
+    }
+    return sum;
+  });
+  for (let i = 0; i < n; i++) {
+    batch(() => {
+      s1.set(i);
+    });
+  }
+}
+
+function updateComputations1to2(n: number, sources: Signal.State<number>[]) {
+  const s1 = sources[0];
+  effect(() => s1.get());
+  effect(() => s1.get());
+  for (let i = 0; i < n / 2; i++) {
+    batch(() => {
+      s1.set(i);
+    });
+  }
+}
+
+function updateComputations1to4(n: number, sources: Signal.State<number>[]) {
+  const s1 = sources[0];
+  effect(() => s1.get());
+  effect(() => s1.get());
+  effect(() => s1.get());
+  effect(() => s1.get());
+  for (let i = 0; i < n / 4; i++) {
+    batch(() => {
+      s1.set(i);
+    });
+  }
+}
+
+function updateComputations1to1000(n: number, sources: Signal.State<number>[]) {
+  const s1 = sources[0];
+  for (let i = 0; i < 1000; i++) {
+    effect(() => s1.get());
+  }
+  for (let i = 0; i < n / 1000; i++) {
+    batch(() => {
+      s1.set(i);
+    });
+  }
+}

--- a/benchmarks/jsonArrayReporter.ts
+++ b/benchmarks/jsonArrayReporter.ts
@@ -1,0 +1,38 @@
+import type {RunnerTestFile} from 'vitest';
+import type {Reporter} from 'vitest/reporters';
+import {writeFile} from 'fs/promises';
+
+class JsonArrayReporter implements Reporter {
+  async onFinished(files: RunnerTestFile[]): Promise<void> {
+    const results: {
+      name: string;
+      unit: string;
+      value: number;
+    }[] = [];
+
+    function processTasks(tasks: RunnerTestFile['tasks'], name: string) {
+      for (const task of tasks) {
+        if (task.type === 'suite') {
+          processTasks(task.tasks, `${name} > ${task.name}`);
+        } else {
+          const value = task.result?.benchmark?.hz;
+          if (value) {
+            results.push({
+              name: `${name} > ${task.name}`,
+              unit: 'Hz',
+              value,
+            });
+          }
+        }
+      }
+    }
+
+    for (const file of files) {
+      processTasks(file.tasks, file.name);
+    }
+
+    await writeFile('benchmarks.json', JSON.stringify(results, null, ' '));
+  }
+}
+
+export default JsonArrayReporter;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.25",
-    "@vitest/browser": "^1.5.3",
+    "@vitest/browser": "^3.0.5",
     "concurrently": "^9.0.1",
     "expect-type": "^1.0.0",
     "prettier": "^3.2.5",
@@ -37,11 +37,11 @@
     "typescript": "latest",
     "vite": "^5.2.6",
     "vite-plugin-dts": "^3.7.3",
-    "vitest": "^1.4.0",
+    "vitest": "^3.0.5",
     "webdriverio": "^8.36.1"
   },
   "volta": {
-    "node": "22.0.0",
+    "node": "22.11.0",
     "pnpm": "9.0.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^20.11.25
         version: 20.12.6
       '@vitest/browser':
-        specifier: ^1.5.3
-        version: 1.5.3(vitest@1.4.0)(webdriverio@8.36.1(encoding@0.1.13)(typescript@5.4.4))
+        specifier: ^3.0.5
+        version: 3.0.5(@types/node@20.12.6)(typescript@5.4.4)(vite@5.2.8(@types/node@20.12.6))(vitest@3.0.5)(webdriverio@8.36.1(encoding@0.1.13)(typescript@5.4.4))
       concurrently:
         specifier: ^9.0.1
         version: 9.0.1
@@ -36,13 +36,17 @@ importers:
         specifier: ^3.7.3
         version: 3.8.1(@types/node@20.12.6)(rollup@4.14.1)(typescript@5.4.4)(vite@5.2.8(@types/node@20.12.6))
       vitest:
-        specifier: ^1.4.0
-        version: 1.4.0(@types/node@20.12.6)(@vitest/browser@1.5.3)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/node@20.12.6)(@vitest/browser@3.0.5)(msw@2.7.0(@types/node@20.12.6)(typescript@5.4.4))
       webdriverio:
         specifier: ^8.36.1
         version: 8.36.1(encoding@0.1.13)(typescript@5.4.4)
 
 packages:
+
+  '@babel/code-frame@7.26.2':
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.24.1':
     resolution: {integrity: sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==}
@@ -52,14 +56,31 @@ packages:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.24.4':
     resolution: {integrity: sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/runtime@7.26.7':
+    resolution: {integrity: sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.24.0':
     resolution: {integrity: sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==}
     engines: {node: '>=6.9.0'}
+
+  '@bundled-es-modules/cookie@2.0.1':
+    resolution: {integrity: sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==}
+
+  '@bundled-es-modules/statuses@1.0.1':
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+
+  '@bundled-es-modules/tough-cookie@0.1.6':
+    resolution: {integrity: sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==}
 
   '@esbuild/aix-ppc64@0.20.2':
     resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}
@@ -202,16 +223,46 @@ packages:
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
+  '@inquirer/confirm@5.1.5':
+    resolution: {integrity: sha512-ZB2Cz8KeMINUvoeDi7IrvghaVkYT2RB0Zb31EaLWOE87u276w4wnApv0SH2qWaJ3r0VSUa3BIuz7qAV2ZvsZlg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.1.6':
+    resolution: {integrity: sha512-Bwh/Zk6URrHwZnSSzAZAKH7YgGYi0xICIBDFOqBQoXNNAzBHw/bgXgLmChfp+GyR3PnChcTbiCTZGC6YJNJkMA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.10':
+    resolution: {integrity: sha512-Ey6176gZmeqZuY/W/nZiUyvmb1/qInjcpiZjXWi6nON+nxJpD1bxtSoBxNliGISae32n6OwbY+TSXPZ1CfS4bw==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@3.0.4':
+    resolution: {integrity: sha512-2MNFrDY8jkFYc9Il9DgLsHhMzuHnOYM1+CUYVWbzu9oT0hC7V7EcYvdCKeoll/Fcci04A+ERZ9wcc7cQ8lTkIA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@jest/schemas@29.6.3':
-    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
   '@manypkg/find-root@2.2.1':
     resolution: {integrity: sha512-34NlypD5mmTY65cFAK7QPgY5Tzt0qXR4ZRXdg97xAlkiLuwXUPBEXy5Hsqzd+7S2acsLxUz6Cs50rlDZQr4xUA==}
@@ -237,6 +288,10 @@ packages:
 
   '@microsoft/tsdoc@0.14.2':
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
+
+  '@mswjs/interceptors@0.37.6':
+    resolution: {integrity: sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==}
+    engines: {node: '>=18'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -326,6 +381,15 @@ packages:
 
   '@octokit/types@9.3.2':
     resolution: {integrity: sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -458,9 +522,6 @@ packages:
   '@rushstack/ts-command-line@4.19.1':
     resolution: {integrity: sha512-J7H768dgcpG60d7skZ5uSSwyCZs/S2HrWP1Ds8d1qYAyaaeJmpmmLr9BVw97RjFzmQPOYnoXcKA4GkqDCkduQg==}
 
-  '@sinclair/typebox@0.27.8':
-    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
-
   '@sindresorhus/is@0.14.0':
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
     engines: {node: '>=6'}
@@ -477,6 +538,16 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
+  '@testing-library/dom@10.4.0':
+    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
+    engines: {node: '>=18'}
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tootallnate/once@1.1.2':
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
     engines: {node: '>= 6'}
@@ -486,6 +557,12 @@ packages:
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
@@ -511,6 +588,12 @@ packages:
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
 
+  '@types/statuses@2.0.5':
+    resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
   '@types/which@2.0.2':
     resolution: {integrity: sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==}
 
@@ -526,12 +609,12 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@vitest/browser@1.5.3':
-    resolution: {integrity: sha512-75XHo+qzbTqvb7kvOCZt4EAphugo8HbeepqcXLWqQiNCYd/PkBWzPu5pSptGVt86WDd8DUVybyq/nGVY1XfWZA==}
+  '@vitest/browser@3.0.5':
+    resolution: {integrity: sha512-5WAWJoucuWcGYU5t0HPBY03k9uogbUEIu4pDmZHoB4Dt+6pXqzDbzEmxGjejZSitSYA3k/udYfuotKNxETVA3A==}
     peerDependencies:
       playwright: '*'
       safaridriver: '*'
-      vitest: 1.5.3
+      vitest: 3.0.5
       webdriverio: '*'
     peerDependenciesMeta:
       playwright:
@@ -541,23 +624,34 @@ packages:
       webdriverio:
         optional: true
 
-  '@vitest/expect@1.4.0':
-    resolution: {integrity: sha512-Jths0sWCJZ8BxjKe+p+eKsoqev1/T8lYcrjavEaz8auEJ4jAVY0GwW3JKmdVU4mmNPLPHixh4GNXP7GFtAiDHA==}
+  '@vitest/expect@3.0.5':
+    resolution: {integrity: sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==}
 
-  '@vitest/runner@1.4.0':
-    resolution: {integrity: sha512-EDYVSmesqlQ4RD2VvWo3hQgTJ7ZrFQ2VSJdfiJiArkCerDAGeyF1i6dHkmySqk573jLp6d/cfqCN+7wUB5tLgg==}
+  '@vitest/mocker@3.0.5':
+    resolution: {integrity: sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
-  '@vitest/snapshot@1.4.0':
-    resolution: {integrity: sha512-saAFnt5pPIA5qDGxOHxJ/XxhMFKkUSBJmVt5VgDsAqPTX6JP326r5C/c9UuCMPoXNzuudTPsYDZCoJ5ilpqG2A==}
+  '@vitest/pretty-format@3.0.5':
+    resolution: {integrity: sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==}
 
-  '@vitest/spy@1.4.0':
-    resolution: {integrity: sha512-Ywau/Qs1DzM/8Uc+yA77CwSegizMlcgTJuYGAi0jujOteJOUf1ujunHThYo243KG9nAyWT3L9ifPYZ5+As/+6Q==}
+  '@vitest/runner@3.0.5':
+    resolution: {integrity: sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==}
 
-  '@vitest/utils@1.4.0':
-    resolution: {integrity: sha512-mx3Yd1/6e2Vt/PUC98DcqTirtfxUyAZ32uK82r8rZzbtBeBo+nqgnjx/LvqQdWsrvNtm14VmurNgcf4nqY5gJg==}
+  '@vitest/snapshot@3.0.5':
+    resolution: {integrity: sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==}
 
-  '@vitest/utils@1.5.3':
-    resolution: {integrity: sha512-rE9DTN1BRhzkzqNQO+kw8ZgfeEBCLXiHJwetk668shmNBpSagQxneT5eSqEBLP+cqSiAeecvQmbpFfdMyLcIQA==}
+  '@vitest/spy@3.0.5':
+    resolution: {integrity: sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==}
+
+  '@vitest/utils@3.0.5':
+    resolution: {integrity: sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==}
 
   '@volar/language-core@1.11.1':
     resolution: {integrity: sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==}
@@ -612,15 +706,6 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
-  acorn-walk@8.3.2:
-    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
-    engines: {node: '>=0.4.0'}
-
-  acorn@8.11.3:
-    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -639,6 +724,10 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -687,8 +776,9 @@ packages:
   assert-never@1.2.1:
     resolution: {integrity: sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==}
 
-  assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
@@ -778,9 +868,9 @@ packages:
     resolution: {integrity: sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==}
     engines: {node: '>=8'}
 
-  chai@4.4.1:
-    resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
-    engines: {node: '>=4'}
+  chai@5.1.2:
+    resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
+    engines: {node: '>=12'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -790,8 +880,9 @@ packages:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -810,6 +901,10 @@ packages:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -846,6 +941,10 @@ packages:
     resolution: {integrity: sha512-wYKvCd/f54sTXJMSfV6Ln/B8UrfLBKOYa+lzc6CHay3Qek+LorVSBdMVfyewFhRbH0Rbabsk4D+3PL/VjQ5gzg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -892,6 +991,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decamelize@6.0.0:
     resolution: {integrity: sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -904,8 +1012,8 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
-  deep-eql@4.1.3:
-    resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
   deep-extend@0.6.0:
@@ -940,13 +1048,12 @@ packages:
   devtools-protocol@0.0.1282316:
     resolution: {integrity: sha512-i7eIqWdVxeXBY/M+v83yRkOV1sTHnr3XYiC0YNBivLIE6hBfE2H0c2o8VC5ynT44yjy+Ei0kLrBQFK/RUKaAHQ==}
 
-  diff-sequences@29.6.3:
-    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
@@ -983,6 +1090,9 @@ packages:
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+
+  es-module-lexer@1.6.0:
+    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
   esbuild@0.20.2:
     resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
@@ -1033,12 +1143,12 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
-  execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-
   expect-type@1.0.0:
     resolution: {integrity: sha512-WcdwgWmGAE48kSHjxPVLriBuvJdJdi1VKTh7HmHvcm6WPdIT1Z04wUVX8BLiqnq0Rz5SnfJ+P0kM1RBqSLLoPQ==}
+    engines: {node: '>=12.0.0'}
+
+  expect-type@1.1.0:
+    resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
     engines: {node: '>=12.0.0'}
 
   extract-zip@2.0.1:
@@ -1136,9 +1246,6 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
-
   get-port@7.1.0:
     resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
     engines: {node: '>=16'}
@@ -1154,10 +1261,6 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
-
-  get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
 
   get-uri@6.0.3:
     resolution: {integrity: sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==}
@@ -1198,6 +1301,10 @@ packages:
   grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
 
+  graphql@16.10.0:
+    resolution: {integrity: sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1209,6 +1316,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -1251,10 +1361,6 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
-
-  human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -1319,6 +1425,9 @@ packages:
   is-lambda@1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
 
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -1334,10 +1443,6 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
-
-  is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -1356,8 +1461,8 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
-  js-tokens@9.0.0:
-    resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -1382,9 +1487,6 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-
-  jsonc-parser@3.2.1:
-    resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -1412,10 +1514,6 @@ packages:
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
-
-  local-pkg@0.5.0:
-    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
-    engines: {node: '>=14'}
 
   locate-app@2.4.11:
     resolution: {integrity: sha512-PS3s33TwvMte9SEWAMtZglr7hrgnEqivajB/zaaQ4u0xOYVtzerPSjSZqNsyMPycJyfJG30c5lpjoJsxvo835g==}
@@ -1446,8 +1544,8 @@ packages:
     resolution: {integrity: sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==}
     engines: {node: '>= 0.6.0'}
 
-  loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+  loupe@3.1.3:
+    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
 
   lowercase-keys@1.0.1:
     resolution: {integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==}
@@ -1473,6 +1571,13 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
   magic-string@0.30.9:
     resolution: {integrity: sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==}
     engines: {node: '>=12'}
@@ -1495,10 +1600,6 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
-
-  mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
 
   mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
@@ -1580,9 +1681,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  mlly@1.6.1:
-    resolution: {integrity: sha512-vLgaHvaeunuOXHSmEbZ9izxPx3USsk8KCQ8iC+aTlp5sKRSoZvwhHh5L9VbKSaVC6sJDqbyohIS76E2VmHIPAA==}
-
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
@@ -1593,8 +1691,25 @@ packages:
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  msw@2.7.0:
+    resolution: {integrity: sha512-BIodwZ19RWfCbYTxWTUfTXc+sg4OwjCAgxU1ZsgmggX/7S3LdUifsbUPJs61j0rWb19CZRGY5if77duhc0uXzw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   muggle-string@0.3.1:
     resolution: {integrity: sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==}
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -1665,10 +1780,6 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
-  npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1680,9 +1791,8 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   p-cancelable@1.1.0:
     resolution: {integrity: sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==}
@@ -1695,10 +1805,6 @@ packages:
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
-
-  p-limit@5.0.0:
-    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
-    engines: {node: '>=18'}
 
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
@@ -1755,10 +1861,6 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
-
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -1766,21 +1868,28 @@ packages:
     resolution: {integrity: sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+  pathe@2.0.2:
+    resolution: {integrity: sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==}
 
-  pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -1789,9 +1898,6 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
-
-  pkg-types@1.0.3:
-    resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
 
   postcss@8.4.38:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
@@ -1811,9 +1917,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  pretty-format@29.7.0:
-    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   proc-log@4.2.0:
     resolution: {integrity: sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==}
@@ -1853,6 +1959,9 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
 
@@ -1872,6 +1981,9 @@ packages:
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -1886,8 +1998,8 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-is@18.2.0:
-    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -1902,6 +2014,9 @@ packages:
 
   readdir-glob@1.1.3:
     resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
+
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   registry-auth-token@4.2.2:
     resolution: {integrity: sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==}
@@ -1918,6 +2033,9 @@ packages:
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -2020,9 +2138,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  sirv@2.0.4:
-    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
-    engines: {node: '>= 10'}
+  sirv@3.0.0:
+    resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
+    engines: {node: '>=18'}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -2084,11 +2202,18 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.7.0:
-    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  std-env@3.8.0:
+    resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
   streamx@2.16.1:
     resolution: {integrity: sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -2124,10 +2249,6 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
-  strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
-
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -2135,9 +2256,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  strip-literal@2.1.0:
-    resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2174,15 +2292,22 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
-  tinybench@2.6.0:
-    resolution: {integrity: sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==}
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinypool@0.8.3:
-    resolution: {integrity: sha512-Ud7uepAklqRH1bvwy22ynrliC7Dljz7Tm8M/0RBUW+YRa4YHhZ6e4PpgE+fu1zr/WqB1kbeuVrdfeuyIBpy4tw==}
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.0.2:
+    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@2.2.1:
-    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   to-fast-properties@2.0.0:
@@ -2201,6 +2326,10 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -2211,9 +2340,9 @@ packages:
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  type-detect@4.0.8:
-    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
-    engines: {node: '>=4'}
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
 
   type-fest@2.13.0:
     resolution: {integrity: sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==}
@@ -2222,6 +2351,10 @@ packages:
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
+
+  type-fest@4.34.1:
+    resolution: {integrity: sha512-6kSc32kT0rbwxD6QL1CYe8IqdzN/J/ILMrNK+HMQCKH3insCDRY/3ITb0vcBss0a3t72fzh2YSzj8ko1HgwT3g==}
+    engines: {node: '>=16'}
 
   typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
@@ -2232,9 +2365,6 @@ packages:
     resolution: {integrity: sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  ufo@1.5.3:
-    resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
 
   unbzip2-stream@1.4.3:
     resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
@@ -2255,6 +2385,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -2268,6 +2402,9 @@ packages:
   url-parse-lax@3.0.0:
     resolution: {integrity: sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==}
     engines: {node: '>=4'}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   userhome@1.0.0:
     resolution: {integrity: sha512-ayFKY3H+Pwfy4W98yPdtH1VqH4psDeyW8lYYFzfecR9d6hqLpqhecktvYR3SEEXt7vG0S1JEpciI3g94pMErig==}
@@ -2287,9 +2424,9 @@ packages:
     resolution: {integrity: sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==}
     engines: {node: '>= 0.10'}
 
-  vite-node@1.4.0:
-    resolution: {integrity: sha512-VZDAseqjrHgNd4Kh8icYHWzTKSCZMhia7GyHfhtzLW33fZlG9SwsB6CEhgyVOWkJfJ2pFLrp/Gj1FSfAiqH9Lw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite-node@3.0.5:
+    resolution: {integrity: sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   vite-plugin-dts@3.8.1:
@@ -2330,19 +2467,22 @@ packages:
       terser:
         optional: true
 
-  vitest@1.4.0:
-    resolution: {integrity: sha512-gujzn0g7fmwf83/WzrDTnncZt2UiXP41mHuFYFrdwaLRVQ6JYQEiME2IfEjU3vcFL3VKa75XhI3lFgn+hfVsQw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vitest@3.0.5:
+    resolution: {integrity: sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.4.0
-      '@vitest/ui': 1.4.0
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.0.5
+      '@vitest/ui': 3.0.5
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -2402,10 +2542,14 @@ packages:
     engines: {node: ^16.13.0 || >=18.0.0}
     hasBin: true
 
-  why-is-node-running@2.2.2:
-    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -2432,6 +2576,18 @@ packages:
 
   ws@8.17.0:
     resolution: {integrity: sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2472,9 +2628,9 @@ packages:
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
-  yocto-queue@1.0.0:
-    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
-    engines: {node: '>=12.20'}
+  yoctocolors-cjs@2.1.2:
+    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
 
   z-schema@5.0.5:
     resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
@@ -2487,19 +2643,44 @@ packages:
 
 snapshots:
 
+  '@babel/code-frame@7.26.2':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.9
+      js-tokens: 4.0.0
+      picocolors: 1.0.0
+
   '@babel/helper-string-parser@7.24.1': {}
 
   '@babel/helper-validator-identifier@7.22.20': {}
 
+  '@babel/helper-validator-identifier@7.25.9': {}
+
   '@babel/parser@7.24.4':
     dependencies:
       '@babel/types': 7.24.0
+
+  '@babel/runtime@7.26.7':
+    dependencies:
+      regenerator-runtime: 0.14.1
 
   '@babel/types@7.24.0':
     dependencies:
       '@babel/helper-string-parser': 7.24.1
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
+
+  '@bundled-es-modules/cookie@2.0.1':
+    dependencies:
+      cookie: 0.7.2
+
+  '@bundled-es-modules/statuses@1.0.1':
+    dependencies:
+      statuses: 2.0.1
+
+  '@bundled-es-modules/tough-cookie@0.1.6':
+    dependencies:
+      '@types/tough-cookie': 4.0.5
+      tough-cookie: 4.1.4
 
   '@esbuild/aix-ppc64@0.20.2':
     optional: true
@@ -2572,6 +2753,32 @@ snapshots:
 
   '@gar/promisify@1.1.3': {}
 
+  '@inquirer/confirm@5.1.5(@types/node@20.12.6)':
+    dependencies:
+      '@inquirer/core': 10.1.6(@types/node@20.12.6)
+      '@inquirer/type': 3.0.4(@types/node@20.12.6)
+    optionalDependencies:
+      '@types/node': 20.12.6
+
+  '@inquirer/core@10.1.6(@types/node@20.12.6)':
+    dependencies:
+      '@inquirer/figures': 1.0.10
+      '@inquirer/type': 3.0.4(@types/node@20.12.6)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 20.12.6
+
+  '@inquirer/figures@1.0.10': {}
+
+  '@inquirer/type@3.0.4(@types/node@20.12.6)':
+    optionalDependencies:
+      '@types/node': 20.12.6
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -2581,11 +2788,9 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@jest/schemas@29.6.3':
-    dependencies:
-      '@sinclair/typebox': 0.27.8
-
   '@jridgewell/sourcemap-codec@1.4.15': {}
+
+  '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@manypkg/find-root@2.2.1':
     dependencies:
@@ -2639,6 +2844,15 @@ snapshots:
       resolve: 1.19.0
 
   '@microsoft/tsdoc@0.14.2': {}
+
+  '@mswjs/interceptors@0.37.6':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2772,6 +2986,15 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 18.1.1
 
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -2894,8 +3117,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@sinclair/typebox@0.27.8': {}
-
   '@sindresorhus/is@0.14.0': {}
 
   '@sindresorhus/is@5.6.0': {}
@@ -2908,11 +3129,30 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@testing-library/dom@10.4.0':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/runtime': 7.26.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+
   '@tootallnate/once@1.1.2': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@types/argparse@1.0.38': {}
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/cookie@0.6.0': {}
 
   '@types/estree@1.0.5': {}
 
@@ -2938,6 +3178,10 @@ snapshots:
 
   '@types/semver@7.5.8': {}
 
+  '@types/statuses@2.0.5': {}
+
+  '@types/tough-cookie@4.0.5': {}
+
   '@types/which@2.0.2': {}
 
   '@types/ws@8.5.10':
@@ -2955,50 +3199,67 @@ snapshots:
       '@types/node': 20.12.6
     optional: true
 
-  '@vitest/browser@1.5.3(vitest@1.4.0)(webdriverio@8.36.1(encoding@0.1.13)(typescript@5.4.4))':
+  '@vitest/browser@3.0.5(@types/node@20.12.6)(typescript@5.4.4)(vite@5.2.8(@types/node@20.12.6))(vitest@3.0.5)(webdriverio@8.36.1(encoding@0.1.13)(typescript@5.4.4))':
     dependencies:
-      '@vitest/utils': 1.5.3
-      magic-string: 0.30.9
-      sirv: 2.0.4
-      vitest: 1.4.0(@types/node@20.12.6)(@vitest/browser@1.5.3)
+      '@testing-library/dom': 10.4.0
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@vitest/mocker': 3.0.5(msw@2.7.0(@types/node@20.12.6)(typescript@5.4.4))(vite@5.2.8(@types/node@20.12.6))
+      '@vitest/utils': 3.0.5
+      magic-string: 0.30.17
+      msw: 2.7.0(@types/node@20.12.6)(typescript@5.4.4)
+      sirv: 3.0.0
+      tinyrainbow: 2.0.0
+      vitest: 3.0.5(@types/node@20.12.6)(@vitest/browser@3.0.5)(msw@2.7.0(@types/node@20.12.6)(typescript@5.4.4))
+      ws: 8.18.0
     optionalDependencies:
       webdriverio: 8.36.1(encoding@0.1.13)(typescript@5.4.4)
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vite
 
-  '@vitest/expect@1.4.0':
+  '@vitest/expect@3.0.5':
     dependencies:
-      '@vitest/spy': 1.4.0
-      '@vitest/utils': 1.4.0
-      chai: 4.4.1
+      '@vitest/spy': 3.0.5
+      '@vitest/utils': 3.0.5
+      chai: 5.1.2
+      tinyrainbow: 2.0.0
 
-  '@vitest/runner@1.4.0':
+  '@vitest/mocker@3.0.5(msw@2.7.0(@types/node@20.12.6)(typescript@5.4.4))(vite@5.2.8(@types/node@20.12.6))':
     dependencies:
-      '@vitest/utils': 1.4.0
-      p-limit: 5.0.0
-      pathe: 1.1.2
-
-  '@vitest/snapshot@1.4.0':
-    dependencies:
-      magic-string: 0.30.9
-      pathe: 1.1.2
-      pretty-format: 29.7.0
-
-  '@vitest/spy@1.4.0':
-    dependencies:
-      tinyspy: 2.2.1
-
-  '@vitest/utils@1.4.0':
-    dependencies:
-      diff-sequences: 29.6.3
+      '@vitest/spy': 3.0.5
       estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
+      magic-string: 0.30.17
+    optionalDependencies:
+      msw: 2.7.0(@types/node@20.12.6)(typescript@5.4.4)
+      vite: 5.2.8(@types/node@20.12.6)
 
-  '@vitest/utils@1.5.3':
+  '@vitest/pretty-format@3.0.5':
     dependencies:
-      diff-sequences: 29.6.3
-      estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.0.5':
+    dependencies:
+      '@vitest/utils': 3.0.5
+      pathe: 2.0.2
+
+  '@vitest/snapshot@3.0.5':
+    dependencies:
+      '@vitest/pretty-format': 3.0.5
+      magic-string: 0.30.17
+      pathe: 2.0.2
+
+  '@vitest/spy@3.0.5':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@3.0.5':
+    dependencies:
+      '@vitest/pretty-format': 3.0.5
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
 
   '@volar/language-core@1.11.1':
     dependencies:
@@ -3093,10 +3354,6 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
-  acorn-walk@8.3.2: {}
-
-  acorn@8.11.3: {}
-
   agent-base@6.0.2:
     dependencies:
       debug: 4.3.4
@@ -3124,6 +3381,10 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
 
   ansi-regex@5.0.1: {}
 
@@ -3173,7 +3434,7 @@ snapshots:
 
   assert-never@1.2.1: {}
 
-  assertion-error@1.1.0: {}
+  assertion-error@2.0.1: {}
 
   ast-types@0.13.4:
     dependencies:
@@ -3292,15 +3553,13 @@ snapshots:
       normalize-url: 4.5.1
       responselike: 1.0.2
 
-  chai@4.4.1:
+  chai@5.1.2:
     dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.3
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.0.8
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.3
+      pathval: 2.0.0
 
   chalk@4.1.2:
     dependencies:
@@ -3309,9 +3568,7 @@ snapshots:
 
   chalk@5.3.0: {}
 
-  check-error@1.0.3:
-    dependencies:
-      get-func-name: 2.0.2
+  check-error@2.1.1: {}
 
   chownr@2.0.0: {}
 
@@ -3330,6 +3587,8 @@ snapshots:
       parse5: 5.1.1
       parse5-htmlparser2-tree-adapter: 6.0.1
       yargs: 16.2.0
+
+  cli-width@4.1.0: {}
 
   cliui@7.0.4:
     dependencies:
@@ -3377,6 +3636,8 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 17.7.2
 
+  cookie@0.7.2: {}
+
   core-util-is@1.0.3: {}
 
   crc-32@1.2.2: {}
@@ -3412,6 +3673,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   decamelize@6.0.0: {}
 
   decompress-response@3.3.0:
@@ -3422,9 +3687,7 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
-  deep-eql@4.1.3:
-    dependencies:
-      type-detect: 4.0.8
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -3448,11 +3711,11 @@ snapshots:
 
   devtools-protocol@0.0.1282316: {}
 
-  diff-sequences@29.6.3: {}
-
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dom-accessibility-api@0.5.16: {}
 
   duplexer2@0.1.4:
     dependencies:
@@ -3492,6 +3755,8 @@ snapshots:
   entities@4.5.0: {}
 
   err-code@2.0.3: {}
+
+  es-module-lexer@1.6.0: {}
 
   esbuild@0.20.2:
     optionalDependencies:
@@ -3569,19 +3834,9 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  execa@8.0.1:
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.3.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
-
   expect-type@1.0.0: {}
+
+  expect-type@1.1.0: {}
 
   extract-zip@2.0.1:
     dependencies:
@@ -3699,8 +3954,6 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-func-name@2.0.2: {}
-
   get-port@7.1.0: {}
 
   get-stream@4.1.0:
@@ -3712,8 +3965,6 @@ snapshots:
       pump: 3.0.0
 
   get-stream@6.0.1: {}
-
-  get-stream@8.0.1: {}
 
   get-uri@6.0.3:
     dependencies:
@@ -3803,6 +4054,8 @@ snapshots:
 
   grapheme-splitter@1.0.4: {}
 
+  graphql@16.10.0: {}
+
   has-flag@4.0.0: {}
 
   hasown@2.0.2:
@@ -3810,6 +4063,8 @@ snapshots:
       function-bind: 1.1.2
 
   he@1.2.0: {}
+
+  headers-polyfill@4.0.3: {}
 
   highlight.js@10.7.3: {}
 
@@ -3860,8 +4115,6 @@ snapshots:
   human-signals@1.1.1: {}
 
   human-signals@2.1.0: {}
-
-  human-signals@5.0.0: {}
 
   humanize-ms@1.2.1:
     dependencies:
@@ -3914,6 +4167,8 @@ snapshots:
 
   is-lambda@1.0.1: {}
 
+  is-node-process@1.2.0: {}
+
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -3921,8 +4176,6 @@ snapshots:
   is-plain-object@5.0.0: {}
 
   is-stream@2.0.1: {}
-
-  is-stream@3.0.0: {}
 
   isarray@1.0.0: {}
 
@@ -3938,7 +4191,7 @@ snapshots:
 
   jju@1.4.0: {}
 
-  js-tokens@9.0.0: {}
+  js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
     dependencies:
@@ -3958,8 +4211,6 @@ snapshots:
   json-parse-even-better-errors@3.0.2: {}
 
   json-schema-traverse@0.4.1: {}
-
-  jsonc-parser@3.2.1: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -3991,11 +4242,6 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  local-pkg@0.5.0:
-    dependencies:
-      mlly: 1.6.1
-      pkg-types: 1.0.3
-
   locate-app@2.4.11:
     dependencies:
       '@promptbook/utils': 0.45.0
@@ -4020,9 +4266,7 @@ snapshots:
 
   loglevel@1.9.1: {}
 
-  loupe@2.3.7:
-    dependencies:
-      get-func-name: 2.0.2
+  loupe@3.1.3: {}
 
   lowercase-keys@1.0.1: {}
 
@@ -4037,6 +4281,12 @@ snapshots:
       yallist: 4.0.0
 
   lru-cache@7.18.3: {}
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.9:
     dependencies:
@@ -4074,8 +4324,6 @@ snapshots:
       picomatch: 2.3.1
 
   mimic-fn@2.1.0: {}
-
-  mimic-fn@4.0.0: {}
 
   mimic-response@1.0.1: {}
 
@@ -4148,20 +4396,42 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
-  mlly@1.6.1:
-    dependencies:
-      acorn: 8.11.3
-      pathe: 1.1.2
-      pkg-types: 1.0.3
-      ufo: 1.5.3
-
   moment@2.30.1: {}
 
   mrmime@2.0.0: {}
 
   ms@2.1.2: {}
 
+  ms@2.1.3: {}
+
+  msw@2.7.0(@types/node@20.12.6)(typescript@5.4.4):
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.1
+      '@bundled-es-modules/statuses': 1.0.1
+      '@bundled-es-modules/tough-cookie': 0.1.6
+      '@inquirer/confirm': 5.1.5(@types/node@20.12.6)
+      '@mswjs/interceptors': 0.37.6
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.5
+      graphql: 16.10.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.34.1
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.4.4
+    transitivePeerDependencies:
+      - '@types/node'
+
   muggle-string@0.3.1: {}
+
+  mute-stream@2.0.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -4226,10 +4496,6 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  npm-run-path@5.3.0:
-    dependencies:
-      path-key: 4.0.0
-
   object-assign@4.1.1: {}
 
   once@1.4.0:
@@ -4240,9 +4506,7 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  onetime@6.0.0:
-    dependencies:
-      mimic-fn: 4.0.0
+  outvariant@1.4.3: {}
 
   p-cancelable@1.1.0: {}
 
@@ -4251,10 +4515,6 @@ snapshots:
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
-
-  p-limit@5.0.0:
-    dependencies:
-      yocto-queue: 1.0.0
 
   p-locate@4.1.0:
     dependencies:
@@ -4313,8 +4573,6 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-key@4.0.0: {}
-
   path-parse@1.0.7: {}
 
   path-scurry@1.10.2:
@@ -4322,25 +4580,23 @@ snapshots:
       lru-cache: 10.2.2
       minipass: 7.0.4
 
+  path-to-regexp@6.3.0: {}
+
   path-type@4.0.0: {}
 
-  pathe@1.1.2: {}
+  pathe@2.0.2: {}
 
-  pathval@1.1.1: {}
+  pathval@2.0.0: {}
 
   pend@1.2.0: {}
 
   picocolors@1.0.0: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
 
   pify@4.0.1: {}
-
-  pkg-types@1.0.3:
-    dependencies:
-      jsonc-parser: 3.2.1
-      mlly: 1.6.1
-      pathe: 1.1.2
 
   postcss@8.4.38:
     dependencies:
@@ -4354,11 +4610,11 @@ snapshots:
 
   prettier@3.2.5: {}
 
-  pretty-format@29.7.0:
+  pretty-format@27.5.1:
     dependencies:
-      '@jest/schemas': 29.6.3
+      ansi-regex: 5.0.1
       ansi-styles: 5.2.0
-      react-is: 18.2.0
+      react-is: 17.0.2
 
   proc-log@4.2.0: {}
 
@@ -4403,6 +4659,10 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   pump@3.0.0:
     dependencies:
       end-of-stream: 1.4.4
@@ -4428,6 +4688,8 @@ snapshots:
 
   query-selector-shadow-dom@1.0.1: {}
 
+  querystringify@2.2.0: {}
+
   queue-microtask@1.2.3: {}
 
   queue-tick@1.0.1: {}
@@ -4441,7 +4703,7 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-is@18.2.0: {}
+  react-is@17.0.2: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -4471,6 +4733,8 @@ snapshots:
   readdir-glob@1.1.3:
     dependencies:
       minimatch: 5.1.6
+
+  regenerator-runtime@0.14.1: {}
 
   registry-auth-token@4.2.2:
     dependencies:
@@ -4506,6 +4770,8 @@ snapshots:
       - supports-color
 
   require-directory@2.1.1: {}
+
+  requires-port@1.0.0: {}
 
   resolve-alpn@1.2.1: {}
 
@@ -4612,7 +4878,7 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sirv@2.0.4:
+  sirv@3.0.0:
     dependencies:
       '@polka/url': 1.0.0-next.25
       mrmime: 2.0.0
@@ -4675,7 +4941,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.7.0: {}
+  statuses@2.0.1: {}
+
+  std-env@3.8.0: {}
 
   streamx@2.16.1:
     dependencies:
@@ -4683,6 +4951,8 @@ snapshots:
       queue-tick: 1.0.1
     optionalDependencies:
       bare-events: 2.2.2
+
+  strict-event-emitter@0.5.1: {}
 
   string-argv@0.3.2: {}
 
@@ -4718,15 +4988,9 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
-  strip-final-newline@3.0.0: {}
-
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
-
-  strip-literal@2.1.0:
-    dependencies:
-      js-tokens: 9.0.0
 
   supports-color@7.2.0:
     dependencies:
@@ -4777,11 +5041,15 @@ snapshots:
 
   through@2.3.8: {}
 
-  tinybench@2.6.0: {}
+  tinybench@2.9.0: {}
 
-  tinypool@0.8.3: {}
+  tinyexec@0.3.2: {}
 
-  tinyspy@2.2.1: {}
+  tinypool@1.0.2: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   to-fast-properties@2.0.0: {}
 
@@ -4793,23 +5061,30 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
   tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
 
   tslib@2.6.2: {}
 
-  type-detect@4.0.8: {}
+  type-fest@0.21.3: {}
 
   type-fest@2.13.0: {}
 
   type-fest@2.19.0: {}
 
+  type-fest@4.34.1: {}
+
   typescript@5.4.2: {}
 
   typescript@5.4.4: {}
-
-  ufo@1.5.3: {}
 
   unbzip2-stream@1.4.3:
     dependencies:
@@ -4830,6 +5105,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  universalify@0.2.0: {}
+
   universalify@2.0.1: {}
 
   unzipper@0.11.4:
@@ -4848,6 +5125,11 @@ snapshots:
     dependencies:
       prepend-http: 2.0.0
 
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
+
   userhome@1.0.0: {}
 
   util-deprecate@1.0.2: {}
@@ -4861,12 +5143,12 @@ snapshots:
 
   validator@13.11.0: {}
 
-  vite-node@1.4.0(@types/node@20.12.6):
+  vite-node@3.0.5(@types/node@20.12.6):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4
-      pathe: 1.1.2
-      picocolors: 1.0.0
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
+      pathe: 2.0.2
       vite: 5.2.8(@types/node@20.12.6)
     transitivePeerDependencies:
       - '@types/node'
@@ -4904,34 +5186,35 @@ snapshots:
       '@types/node': 20.12.6
       fsevents: 2.3.3
 
-  vitest@1.4.0(@types/node@20.12.6)(@vitest/browser@1.5.3):
+  vitest@3.0.5(@types/node@20.12.6)(@vitest/browser@3.0.5)(msw@2.7.0(@types/node@20.12.6)(typescript@5.4.4)):
     dependencies:
-      '@vitest/expect': 1.4.0
-      '@vitest/runner': 1.4.0
-      '@vitest/snapshot': 1.4.0
-      '@vitest/spy': 1.4.0
-      '@vitest/utils': 1.4.0
-      acorn-walk: 8.3.2
-      chai: 4.4.1
-      debug: 4.3.4
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.9
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      tinybench: 2.6.0
-      tinypool: 0.8.3
+      '@vitest/expect': 3.0.5
+      '@vitest/mocker': 3.0.5(msw@2.7.0(@types/node@20.12.6)(typescript@5.4.4))(vite@5.2.8(@types/node@20.12.6))
+      '@vitest/pretty-format': 3.0.5
+      '@vitest/runner': 3.0.5
+      '@vitest/snapshot': 3.0.5
+      '@vitest/spy': 3.0.5
+      '@vitest/utils': 3.0.5
+      chai: 5.1.2
+      debug: 4.4.0
+      expect-type: 1.1.0
+      magic-string: 0.30.17
+      pathe: 2.0.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
       vite: 5.2.8(@types/node@20.12.6)
-      vite-node: 1.4.0(@types/node@20.12.6)
-      why-is-node-running: 2.2.2
+      vite-node: 3.0.5(@types/node@20.12.6)
+      why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.12.6
-      '@vitest/browser': 1.5.3(vitest@1.4.0)(webdriverio@8.36.1(encoding@0.1.13)(typescript@5.4.4))
+      '@vitest/browser': 3.0.5(@types/node@20.12.6)(typescript@5.4.4)(vite@5.2.8(@types/node@20.12.6))(vitest@3.0.5)(webdriverio@8.36.1(encoding@0.1.13)(typescript@5.4.4))
     transitivePeerDependencies:
       - less
       - lightningcss
+      - msw
       - sass
       - stylus
       - sugarss
@@ -5026,10 +5309,16 @@ snapshots:
     dependencies:
       isexe: 3.1.1
 
-  why-is-node-running@2.2.2:
+  why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -5048,6 +5337,8 @@ snapshots:
   ws@8.13.0: {}
 
   ws@8.17.0: {}
+
+  ws@8.18.0: {}
 
   y18n@5.0.8: {}
 
@@ -5092,7 +5383,7 @@ snapshots:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
 
-  yocto-queue@1.0.0: {}
+  yoctocolors-cjs@2.1.2: {}
 
   z-schema@5.0.5:
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,10 @@
 import {dirname, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {defineConfig} from 'vite';
+import JsonArrayReporter from './benchmarks/jsonArrayReporter';
 import dts from 'vite-plugin-dts';
+
+process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ''} --expose-gc`;
 
 const entry = join(dirname(fileURLToPath(import.meta.url)), './src/index.ts');
 
@@ -13,6 +16,12 @@ export default defineConfig({
       entry,
       formats: ['es'],
       fileName: 'index',
+    },
+  },
+  test: {
+    benchmark: {
+      include: ['benchmarks/**/*.bench.ts'],
+      reporters: ['default', new JsonArrayReporter()],
     },
   },
 });


### PR DESCRIPTION
Following the discussing today with @NullVoxPopuli during the community call, I am opening this PR to add benchmarks to the CI of this repository.
This PR is inspired from similar PRs ([here](https://github.com/AmadeusITGroup/tansu/pull/142) and [there](https://github.com/AmadeusITGroup/tansu/pull/143)) that we did on [tansu](https://github.com/AmadeusITGroup/tansu) (our own signal implementation).
It uses the [benchmark-action/github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark) action. For this to work, a gh-pages branch must exist in the repository. The action will publish benchmarks on the gh-pages branch, with graphs ([cf an example here](https://amadeusitgroup.github.io/tansu/dev/bench/)). It will also compare benchmarks of a PR with the main branch (cf [here](https://github.com/AmadeusITGroup/tansu/actions/runs/11797572444#summary-32861849021)).