### PR TITLE
fix assignment of subtypes (#7)

### DIFF
--- a/src/computed.ts
+++ b/src/computed.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {defaultEquals, ValueEqualityFn} from './equality.js';
+import {defaultEquals, ValueEqualityComparer} from './equality.js';
 import {
   consumerAfterComputation,
   consumerBeforeComputation,
@@ -22,7 +22,7 @@ import {
  *
  * `Computed`s are both producers and consumers of reactivity.
  */
-export interface ComputedNode<T> extends ReactiveNode {
+export interface ComputedNode<T> extends ReactiveNode, ValueEqualityComparer<T> {
   /**
    * Current value of the computation, or one of the sentinel values above (`UNSET`, `COMPUTING`,
    * `ERROR`).
@@ -39,8 +39,6 @@ export interface ComputedNode<T> extends ReactiveNode {
    * The computation function which will produce a new value.
    */
   computation: () => T;
-
-  equal: ValueEqualityFn<T>;
 }
 
 export type ComputedGetter<T> = (() => T) & {

--- a/src/equality.ts
+++ b/src/equality.ts
@@ -7,9 +7,13 @@
  */
 
 /**
- * A comparison function which can determine if two values are equal.
+ * An interface representing a comparison strategy to determine if two values are equal.
+ *
+ * @template T The type of the values to be compared.
  */
-export type ValueEqualityFn<T> = (a: T, b: T) => boolean;
+export interface ValueEqualityComparer<T> {
+  equal(a: T, b: T): boolean;
+}
 
 /**
  * The default equality function used for `signal` and `computed`, which uses referential equality.

--- a/src/public-api-types.ts
+++ b/src/public-api-types.ts
@@ -93,3 +93,19 @@ expectTypeOf<keyof Signal.subtle.Watcher & string>().toEqualTypeOf<
 expectTypeOf(new Signal.State(0)).toEqualTypeOf<Signal.State<number>>();
 expectTypeOf(new Signal.State(0).get()).toEqualTypeOf<number>();
 expectTypeOf(new Signal.State(0).set(1)).toEqualTypeOf<void>();
+
+/**
+ * Assigning subtypes works
+ */
+expectTypeOf<Signal.Computed<Narrower>>().toMatchTypeOf<Signal.Computed<Broader>>();
+expectTypeOf<Signal.State<Narrower>>().toMatchTypeOf<Signal.State<Broader>>();
+
+/**
+ * Test data types
+ */
+interface Broader {
+  strProp: string;
+}
+interface Narrower extends Broader {
+  numProp: number;
+}

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {defaultEquals, ValueEqualityFn} from './equality.js';
+import {defaultEquals, ValueEqualityComparer} from './equality.js';
 import {throwInvalidWriteToSignalError} from './errors.js';
 import {
   producerAccessed,
@@ -30,9 +30,8 @@ declare const ngDevMode: boolean | undefined;
  */
 let postSignalSetFn: (() => void) | null = null;
 
-export interface SignalNode<T> extends ReactiveNode {
+export interface SignalNode<T> extends ReactiveNode, ValueEqualityComparer<T> {
   value: T;
-  equal: ValueEqualityFn<T>;
 }
 
 export type SignalBaseGetter<T> = (() => T) & {readonly [SIGNAL]: unknown};


### PR DESCRIPTION
There is also an alternative solution - not to introduce a new interface.
Then need to change all the `equal` declarations from a property to a method, but it doesn't look elegant.
`equal(...args: Parameters<ValueEqualityFn<T>>): ReturnType<ValueEqualityFn<T>>;`