### PR TITLE
Add: tests for Signal.State initialization with various data types

### DIFF
--- a/tests/Signal/state.test.ts
+++ b/tests/Signal/state.test.ts
@@ -54,4 +54,28 @@ describe('Signal.State', () => {
       expect(calls).toBe(2);
     });
   });
+
+  describe('Signal.State Initialization', () => {
+    it('should initialize with a number', () => {
+      const state = new Signal.State(42);
+      expect(state.get()).toBe(42);
+    });
+
+    it('should initialize with a string', () => {
+      const state = new Signal.State('Hello');
+      expect(state.get()).toBe('Hello');
+    });
+
+    it('should initialize with an object', () => {
+      const obj = { key: 'value' };
+      const state = new Signal.State(obj);
+      expect(state.get()).toEqual(obj);
+    });
+
+    it('should initialize with an array', () => {
+      const arr = [1, 2, 3];
+      const state = new Signal.State(arr);
+      expect(state.get()).toEqual(arr);
+    });
+  });
 });

--- a/tests/Signal/state.test.ts
+++ b/tests/Signal/state.test.ts
@@ -67,7 +67,7 @@ describe('Signal.State', () => {
     });
 
     it('should initialize with an object', () => {
-      const obj = { key: 'value' };
+      const obj = {key: 'value'};
       const state = new Signal.State(obj);
       expect(state.get()).toEqual(obj);
     });


### PR DESCRIPTION
issue  - https://github.com/tc39/proposal-signals/issues/70

**Changes Made**:
- Added tests to verify that `Signal.State` can be initialized with different types, including numbers, strings, objects, and arrays.