### PR TITLE
Update tsconfig.json to fix error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "strict": true,
     "composite": true,
     "forceConsistentCasingInFileNames": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true
   },
   "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/dist/**/*"],
   "include": ["src"]


### PR DESCRIPTION
Without this change, I get the error:

    Option 'allowImportingTsExtensions' can only be used when either 'noEmit' or 'emitDeclarationOnly' is set.

I'm not sure which of the two is correct, but this fixes that error.